### PR TITLE
README Update: instructions for creating OpenWeather API key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ We know your time is valuable, so spend as much or as little time as you like.
 ### Goal: Build a Weather Forecasting app
 
 * Use [OpenWeather's REST API](https://openweathermap.org/api) to build an Android application that displays the current weather in New York.
+  - Signup [here](https://openweathermap.org/home/sign_up) to create an account and generate your own API key. You will need the key in order for your app to be authorized to access OpenWeather's endpoints.
+  - The key generated in your account needs to be place in the `key` constant inside the `WeatherApi` class.
 * Retrieve the weather information for New York City using the [One Call API](https://openweathermap.org/api/one-call-api).
   - To save time, you can hardcode the city's latitude/longitude coordinates (`40.725302, -73.997776`).
   - In the project, you'll find an existing `WeatherApi` implementation with the required endpoint.

--- a/app/src/main/java/com/example/androidchallenge/network/api/WeatherApi.kt
+++ b/app/src/main/java/com/example/androidchallenge/network/api/WeatherApi.kt
@@ -5,7 +5,7 @@ import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Query
 
-private const val key = "59ac41458256ef1fc2ebfddda1ded2da"
+private const val key = "insert_your_key_here"
 
 interface WeatherApi {
 


### PR DESCRIPTION
* To avoid overuse of the previously provided OpenWeather API key, we have updated the project's instructions to guide candidates into creating their own OpenWeather account and key.